### PR TITLE
Add -lpthread to LDFLAGS

### DIFF
--- a/stfl.go
+++ b/stfl.go
@@ -2,7 +2,7 @@ package stfl
 
 /*
 #cgo pkg-config: stfl
-#cgo LDFLAGS: -lncursesw
+#cgo LDFLAGS: -lncursesw -lpthread
 #include <stdlib.h>
 #include <stfl.h>
 #include "stfl_wrapper.h"


### PR DESCRIPTION
Add -lpthread to LDFLAGS

Fixes "undefined reference to `pthread_key_create'".
